### PR TITLE
Adding a list of ladies past speaker names and talks

### DIFF
--- a/events/past-speaker.md
+++ b/events/past-speaker.md
@@ -6,6 +6,8 @@ Feel free to contact them for speaking opportunities.
 
 The list is ordered chronologically, descending.
 
+> If you are on this list and wish to be deleted, please open an issue on Github: https://github.com/ladiesOfCodeParis/welcome-kit/issues 
+
 ## 2025
 
 - **Delphine Rigaud** & **Laurine Lenet**, Développeuses Full Stack chez Takima – “Nous non plus, on y croyait pas à nos projets perso” 🇫🇷  

--- a/events/past-speaker.md
+++ b/events/past-speaker.md
@@ -1,0 +1,199 @@
+# List of our last speaker
+
+Find information about all the latest ladies who gave a talk at Ladies of Code Paris.
+
+Feel free to contact them for speaking opportunities.
+
+The list is ordered chronologically, descending.
+
+## 2025
+
+- **Delphine Rigaud** & **Laurine Lenet**, Développeuses Full Stack chez Takima – “Nous non plus, on y croyait pas à nos projets perso” 🇫🇷  
+
+- **Anne‑Flore Bernard**, Developer – “Transformer son API Doc en levier de conversion : benchmark & best practises” 🇫🇷  
+
+- **Sonia Jagourel**, Tech Evangelist chez Believe – “Le bug de la consanguinité logicielle : la crise d’une tech qui ne se remet plus en question.” 🇫🇷  
+
+- **Ajtene Kurtaliqi**, Ingénieure Logiciel à la Société Générale – “TDD : comment casser les vieilles habitudes de coding” 🇫🇷  
+
+- **Morgane Flauder**, Founding Engineer chez Paladin – “Idée de génie ou descente aux enfers ? On a refait notre modèle de données de zéro et migré toute notre codebase 😱 (volontairement)” 🇫🇷  
+
+- **Claire Helme‑Guizon**, Seniorita Machine Learning Engineer at Algolia – “Learning to Rank : Expectation VS Reality” 🇬🇧  
+
+- **Patricia Boh**, ingénieure logicielle à Radio France – “La pratique personnelle du code” 🇫🇷  
+
+- **Bathilde Rocchia**, Ingénieure Web Freelance – “Démystifier l’IA : de quoi parle‑t‑on ?” 🇫🇷  
+
+- **Melanie Almeida**, Senior PM Growth – “Privacy : it’s not too late” 🇬🇧  
+
+- **Ewa Kadziolka**, développeuse web – “Du Comportement Humain au Comportement du Code : Quand l’ABA Rencontre la programmation” 🇫🇷  
+
+- **Alice Bonhomme‑Biais**, Performance & Leadership coach – “Help ! Pourquoi personne ne répond à mon doc ?” 🇫🇷  
+
+- **Ludi Akue**, CTO Digital chez BPI France – “SheURL.com : 99 % codé par une IA” 🇫🇷  
+
+- **Alice Loeser** – “Soft‑deletion : A Doctolib Horror Story” 🇬🇧  
+
+- **Amanpreet Kaur Colombier** – “Du chef de projet au poste de manager tech dans le Groupe TF1” 🇫🇷  
+
+- **Marianne Carpentier** – “L’IA au cœur de l’innovation côté production chez Newen studios” 🇫🇷
+
+
+## 2024
+
+- **Dina Abakkali**, DevOps Engineer at Scaleway – “Programming can be a team sport” 🇬🇧  
+
+- **Sonia Seddiki**, passionnée de cybersécurité – “À la découverte du code golf ⛳” 🇫🇷  
+
+- **Pénélope Gittos**, Business Developer – Data Science Services @Probabl – “Introduction au machine learning avec scikit-learn” 🇫🇷  
+
+- **Emilie Roberts**, Developer Relations Engineer @Google – “Travailler sur un système d'exploitation (ChromeOS et Android)” 🇫🇷  
+
+- **Audrey Doyen**, Software Developer @FizzUp – “Carnet de bord d'une alternance dans la tech: entre chiffres et réalité(s)” 🇫🇷  
+
+- **Solveig Bougeois**, ex‑Engineering Manager, founder @Workin' Family – “Allier travail et parentalité grâce à Workin' Family” 🇫🇷  
+
+- **Ane Diaz de Tuesta**, Software Engineer chez Datadog – “Parlons d'entretiens techniques” 🇫🇷  
+
+- **Laure Némée**, Co‑founder & CTO de Primary – “Dans la tête d'une hiring manager” 🇫🇷  
+
+- **Marie Terrier**, co‑organisatrice de Ladies of Code – “Présentation de Ladies of Code” 🇫🇷  
+
+- **Anaïs Limpalaër**, Fullstack Engineer chez Doctrine – “Reconversion dans la tech: retour d'expérience” 🇫🇷  
+
+- **Juliette Audema** – “Et si je montais ma boîte ?, retour d'expérience” 🇫🇷  
+
+- **Rym Laabiyad**, Machine Learning Engineer chez Doctrine – “L'IA générative au service du search chez Doctrine” 🇫🇷  
+
+- **Dorra Bartagui­z**, VP Tech à Arolla – "Talk surprise (no title provided)" 
+
+- **Daphné Herve**, Agile tester & DevOps engineer – “Cheat Sheet Postman” 🇬🇧  
+
+- **Félicie Godineau**, Back End Team Lead à Qonto – “La grande histoire d'1 euro sur le réseau bancaire” �🇫🇷  
+
+- **Yulianna Khorolich**, Solutions Architect & Engineering Manager à SFΞIR – “Back to basics. Let's talk MLOps !” 🇬🇧  
+
+- **Marine Sobas**, Engineering Team Lead chez Dataiku – “Qu'est‑ce que les champignons nous apprennent sur l'intelligence artificielle ?” 🇫🇷  
+
+- **Amélie Le Coz**, Software Engineer chez Cap Collectif – “Naviguer dans la tempête : Comprendre et contrer les attaques DDoS” 🇫🇷  
+
+- **Diana Shevchenko**, Software Engineer chez Datadog – “Observability: from macro to micro” 🇬🇧  
+
+## 2023
+
+- **Mélanie Almeida**, Product Manager – “Growth Engineer et autres métiers hybrides pour les profils tech” 🇫🇷  
+
+- **Samah Ghalloussi**, CEO chez AALIA.TECH – “Comment réussir l’intégration de nouveaux collaborateurs dans un projet qui a commencé seul dans son garage…” 🇫🇷  
+
+- **Alice Bonhomme‑Biais**, Software Engineer Coach Freelance – “Growing Beyond the Senior Software Engineer Level” 🇬🇧  
+
+- **Adriana Nava Aguilar**, Full Stack Engineer (.Net / Ng) – “SoCraTes: un-conference pas comme les autres!” 🇫🇷  
+
+- **Marie Sacksick**, Head of Data chez CybelAngel – “10 tips pour de belles data viz ✨️” 🇫🇷  
+
+- **Laïla Atrmouh**, développeuse fullstack – “S'impliquer, Pourquoi ? Comment ?” 🇫🇷  
+
+- **Emma Gaubert**, Développeuse iOS en alternance – “Faire face au syndrome de l'imposteur quand on est en reconversion : tips and tricks” 🇫🇷  
+
+- **Anne‑Marie Tousch**, Senior Data Scientist chez Datadog – “From DevOps to MLOps: practical steps for a smooth transition” 🇬🇧  
+
+- **Sonia Seddiki** – “Le protocole DNS : qu'est‑ce que c'est ? Comment ça marche ? Quelques techniques d'exploitation en cybersécurité” 🇫🇷  
+
+- **Assitan Koné**, CEO et fondatrice de Codistwa – “Comment rester à jour dans une tech en constante évolution : stratégies et outils pour gérer la variété des sujets à apprendre” 🇫🇷  
+
+- **Cynthia Soimansoib**, ingénieure junior R&D chez Automatic Data Processing – “Chrome vs Firefox : le match des DevTools” 🇫🇷  
+
+- **Valérie Mauduit**, ingénieure en mécanique devenue informaticienne – “Mon métier dans les lycées” 🇫🇷  
+
+- **Anaïs Pieropan**, développeuse chez Klaro – “Psychologie et design : comment nos biais cognitifs impactent l'UX” 🇫🇷  
+
+- **Catherine Smet**, Senior designer chez PALO IT – “10 ans dans la tech et toujours dans l'imposture”, ou comment avancer dans son parcours pro dans la tech avec un syndrome de l'imposture 🇫🇷  
+
+- **Sandra Jacinto**, Lead technique front end chez Energisme – “Comment on utilise Nx (nrwl) et ses generators dans notre équipe” 🇫🇷  
+
+- **Suzanne Daurat**, CTO chez Qairn – “La dette technique (mais pas que !)”, ou comment communiquer dessus à l'ensemble des équipes, au-delà de la technique 🇫🇷  
+
+
+## 2022
+
+- **Ane Diaz de Tuesta**, développeuse frontend chez Datadog – “Le Sketchnoting: prise de notes visuelle” 🇫🇷  
+
+- **Sonia Seddiki**, développeuse backend @ Pitchy – “Des secrets dans les pixels ! À la découverte de la stéganographie” 🇫🇷  
+
+- **Laïla Atrmouh**, développeuse full‑stack @ Ubiq – “Qu'est‑ce qu'un offboarding ? Retour d'expérience” 🇫🇷  
+
+- **Ewa Kadziolka**, développeuse junior à la recherche d'un emploi – “Loglan 82 ou le code derrière le rideau de fer” 🇫🇷  
+
+- **Darya Talanina**, Full Stack Software Engineer @ Inato – “Introduction to Hexagonal Architecture” 🇬🇧  
+
+- **Emma Goldblum**, Software Engineer @ Alan – “Moi aussi, je peux le faire (ou comment je suis devenue Software Engineer en codant pour la première fois à 23 ans)” 🇫🇷  
+
+- **Ane Diaz de Tuesta**, Software Engineer @ Datadog – “Le job de mes rêves” 🇫🇷  
+
+- **Aurélie Vache**, DevRel @ OVHcloud – “Tips pour combattre le syndrome de l'imposteur” 🇫🇷  
+
+## 2021
+
+- **Marie Terrier**, CTO @ Yelda – “Ca marche pas, ou comment décrire un bug efficacement” 🇫🇷  
+
+- **Fanny Kilanga**, Full stack developer @ Positive Thinking Company – “l'univers d'un·e développeur·euse” 🇫🇷  
+
+- **Paola Ducolin** – “créer son propre blog en React + Markdown + Next.js” 🇫🇷  
+
+## 2020
+- **Laïla Atrmouh**, développeuse fullstack @ Bureaux A Partager // co‑organisatrice @ Ladies of Code Paris – “Réaliser un side‑project: comment se motiver et les finir !” 🇫🇷  
+
+- **Elisabeth Fainstein**, **Claire Heude**, **Pauline Artemenko** – “Time is short, my strength is limited, the office is a horror : faire avancer son side‑project une ligne de code à la fois” 🇬🇧  
+
+- **Gabriela Gabriel**, Senior Software Engineer @ Blablacar – “Design Systems 101” 🇬🇧  
+
+- **Adèle Gauvrit**, Développeuse @ Theodo – “Mettre en place une stratégie de tests adaptée à son projet” 🇫🇷  
+
+- **Daniela Matos de Carvalho**, Software Engineer @ Dashlane – “How I fixed accessibility on my website” 🇬🇧  
+
+- **Ana Maria Suciu**, Software Developer @ Adventori – “Learning from technical migrations” 🇬🇧  
+
+- **Caroline Chavier**, CEO The Allyance – “Comment réussir ses entretiens ?” 🇫🇷  
+
+- **Emmanuelle Franquelin**, Engineering Manager @ Dashlane – “Que se passe‑t‑il quand on tape google.com ?” 🇫🇷  
+
+- **Paola Ducolin**, Staff Engineer @ Dashlane – “Coding for Humans” 🇬🇧  
+
+- **Morgane Flauder**, Software Engineer chez Alan – “Comment je suis devenue développeuse” 🇫🇷  
+
+- **Cindy Liwenge**, Backend Developer – “Devenir développeuse et prendre le pouvoir” 🇫🇷  
+
+- **Valérie Mauduit**, Data Scientist – “Changer de cap à 45 ans” 🇫🇷  
+
+- **Emmanuelle Franquelin**, Server Engineering Manager @ Dashlane – “Building confidence as a Software Engineer” 🇬🇧  
+
+- **Anna Breyer**, Lead Developper @ 5àSec – “Se reconvertir après 30 ans” 🇫🇷  
+
+- **Caroline Chuong**, Backend Developper @ la coopérative les tilleuls – “De criminologue à développeuse” 🇫🇷  
+
+## 2019
+
+- **Meriam Lachkar**, Senior Software Engineer @ Critéo – “On ne naît pas dev, on le devient” 🇫🇷  
+
+- **Anaïs Pieropan**, Frontend Software Engineer @ Spendesk – “Dev front‑end : tout est dans les détails” 🇫🇷  
+
+- **Aude Rouaux**, Software Engineer @ Everoad – “À la découverte de CQRS et l'Event Sourcing, ce duo de patterns fascinant !” 🇫🇷  
+
+- **Aude Rouaux**, Software Engineer @ Everoad – “Pourquoi et comment utiliser CQRS et l'Event Sourcing, ce duo de patterns fascinant ?” 🇫🇷  
+
+- **Anna Breyer**, Lead Developer @ 5àSec – “Fail Talk - La fois où j’ai fait les erreurs que nous savons tous qu’il ne faut pas faire.” 🇫🇷  
+
+- **Daphne Popin**, Software Engineer @ Alan – “Comment créer sa propre culture de l’ingénierie et comment la maintenir dans le temps ?” 🇫🇷  
+
+- **Marina Vinyes**, Software Engineer in Machine Learning @ Criteo – “Learning the structure of Gaussian Graphical models with unobserved variables.” 🇬🇧  
+
+- **Melanie Warrick**, Google Developer Advocate – “An overview of changing my career into ML and 7 key points of advice that I share as I step through the progression” 🇬🇧  
+
+- **Sameh Ben Fredj**, Data Scientist & IoT Consultant @ Xebia – “A connected bar with deep learning & Greengrass” 🇬🇧  
+
+## 2018
+
+- **Imane ABOU EL MARAI** – “Focus sur les bonnes pratiques et le dév - Security by Design” 🇫🇷  
+
+- **Paola Ducolin** – “Comment débugger chez les clients avec Windbg ? (Démo)” 🇫🇷  
+


### PR DESCRIPTION
Hello @leiluspocus 
I have created a new markdown page in the events folder to list names of past speakers and their talk titles.
Ordered chronologically, descending.

I thought about adding their LinkedIn as well, but maybe they prefer to do it themselves.